### PR TITLE
feat: filter_dir function

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -58,6 +58,10 @@ adapter.root = function(path)
   return lib.files.match_root_pattern("package.json")(path)
 end
 
+function adapter.filter_dir(name)
+  return name ~= "node_modules"
+end
+
 ---@param file_path? string
 ---@return boolean
 function adapter.is_test_file(file_path)


### PR DESCRIPTION
Neotest core has switched to custom file finding, which requires specifying custom filtering. This prevents node_modules being searched for tests