### PR TITLE
bugfix: nil check when no package.json

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -18,7 +18,7 @@ local adapter = { name = "neotest-vitest" }
 local function hasVitestDependency(path)
   local rootPath = util.find_package_json_ancestor(path)
 
-  if not lib.files.exists(rootPath .. "/package.json") then
+  if not (rootPath ~= nil and lib.files.exists(rootPath .. "/package.json")) then
     print("package.json not found")
     return false
   end

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -16,6 +16,10 @@ describe("adapter enabled", function()
   async.it("disable adapter", function()
     assert.Nil(plugin.root("./spec-jest"))
   end)
+
+  async.it("disable adapter no package.json", function ()
+    assert.Nil(plugin.root("."))
+  end)
 end)
 
 describe("is_test_file", function()


### PR DESCRIPTION
When neither working directory nor it's ancestors contain `package.json`, `rootPath` is `nil` resulting in following error: 

![image](https://user-images.githubusercontent.com/35574506/190477133-66dfb163-248d-43d7-8199-7ebcd7fe4cea.png)
