### PR TITLE
Fix: set status to skipped for todo tests

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -296,7 +296,7 @@ local function parsed_json_to_results(data, output_file, consoleOut)
 
       keyid = keyid .. "::" .. name
 
-      if status == "pending" then
+      if status == "pending" or status == "todo" then
         status = "skipped"
       end
 


### PR DESCRIPTION
Fixes the following error:

![2023-06-21_21-44-42_region](https://github.com/marilari88/neotest-vitest/assets/21299126/f8b8f894-8903-4200-b802-e13238905c96)
