### PR TITLE
feat: support vite config file

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -148,7 +148,7 @@ local function getVitestCommand(path)
   return "vitest"
 end
 
-local vitestConfigPattern = util.root_pattern("vitest.config.{js,ts}")
+local vitestConfigPattern = util.root_pattern("{vite,vitest}.config.{js,ts}")
 
 ---@param path string
 ---@return string|nil
@@ -159,14 +159,23 @@ local function getVitestConfig(path)
     return nil
   end
 
-  local vitestJs = util.path.join(rootPath, "vitest.config.js")
-  local vitestTs = util.path.join(rootPath, "vitest.config.ts")
+  -- Ordered by config precedence (https://vitest.dev/config/#configuration)
+  local possibleVitestConfigNames = {
+    "vitest.config.ts",
+    "vitest.config.js",
+    "vite.config.ts",
+    "vite.config.js",
+  }
 
-  if util.path.exists(vitestTs) then
-    return vitestTs
+  for _, configName in ipairs(possibleVitestConfigNames) do
+    local configPath = util.path.join(rootPath, configName)
+
+    if util.path.exists(configPath) then
+      return configPath
+    end
   end
 
-  return vitestJs
+  return nil
 end
 
 local function escapeTestPattern(s)

--- a/spec/config/vite/basic.test.ts
+++ b/spec/config/vite/basic.test.ts
@@ -1,0 +1,5 @@
+import { it } from "vitest";
+
+it("1", () => {
+  console.log("do test");
+});

--- a/spec/config/vite/vite.config.ts
+++ b/spec/config/vite/vite.config.ts
@@ -1,0 +1,5 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from "vite";
+
+export default defineConfig({});

--- a/spec/config/vitest/basic.test.ts
+++ b/spec/config/vitest/basic.test.ts
@@ -1,0 +1,5 @@
+import { it } from "vitest";
+
+it("1", () => {
+  console.log("do test");
+});

--- a/spec/config/vitest/vite.config.ts
+++ b/spec/config/vitest/vite.config.ts
@@ -1,0 +1,5 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from "vite";
+
+export default defineConfig({});

--- a/spec/config/vitest/vitest.config.ts
+++ b/spec/config/vitest/vitest.config.ts
@@ -1,0 +1,5 @@
+/// <reference types="vitest" />
+
+import { defineConfig } from "vite";
+
+export default defineConfig({});

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -150,6 +150,7 @@ describe("build_spec", function()
     assert.contains(command, "--run")
     assert.contains(command, "--reporter=verbose")
     assert.contains(command, "--testNamePattern=.*")
+    assert.contains(command, "--config=./spec/vite.config.ts")
     assert.contains(command, "./spec/basic.test.ts")
     assert.is.truthy(spec.context.file)
     assert.is.truthy(spec.context.results_path)
@@ -171,8 +172,39 @@ describe("build_spec", function()
     assert.contains(command, "--run")
     assert.contains(command, "--reporter=verbose")
     assert.contains(command, "--testNamePattern=^ describe text")
+    assert.contains(command, "--config=./spec/vite.config.ts")
     assert.contains(command, "./spec/basic.test.ts")
     assert.is.truthy(spec.context.file)
     assert.is.truthy(spec.context.results_path)
+  end)
+
+  async.it("uses vite config", function()
+    local positions = plugin.discover_positions("./spec/config/vite/basic.test.ts"):to_list()
+
+    local tree = Tree.from_list(positions, function(pos)
+      return pos.id
+    end)
+
+    local spec = plugin.build_spec({ tree = tree:children()[1] })
+
+    assert.is.truthy(spec)
+    local command = spec.command
+    assert.is.truthy(command)
+    assert.contains(command, "--config=./spec/config/vite/vite.config.ts")
+  end)
+
+  async.it("uses vitest config over vite config", function()
+    local positions = plugin.discover_positions("./spec/config/vitest/basic.test.ts"):to_list()
+
+    local tree = Tree.from_list(positions, function(pos)
+      return pos.id
+    end)
+
+    local spec = plugin.build_spec({ tree = tree:children()[1] })
+
+    assert.is.truthy(spec)
+    local command = spec.command
+    assert.is.truthy(command)
+    assert.contains(command, "--config=./spec/config/vitest/vitest.config.ts")
   end)
 end)


### PR DESCRIPTION
## Changes

* Add support for `vite.config.js` and `vite.config.ts` configuration files

## Motivation

Currently, neotest-vitest only supports `vitest.config.js` and `vitest.config.ts`. However, the Vitest docs call out that `vite.config.js` and `vite.config.ts` are valid configuration files: https://vitest.dev/config/#configuration

This change ensures that projects leveraging `vite.config.js` and `vite.config.ts` can use neotest-vitest without having to restructure or rename their Vitest config files.

## Testing

Unit tests based on the new `./spec/config` directory should cover the support and precedence rules for Vite and Vitest config files. I also went through and tested it manually to make sure it was actually working 🙂 