### PR TITLE
✨ Detect vitest dependency in monorepo

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -13,6 +13,39 @@ local util = require("neotest-vitest.util")
 ---@type neotest.Adapter
 local adapter = { name = "neotest-vitest" }
 
+local rootPackageJson = vim.fn.getcwd() .. "/package.json"
+
+---@return boolean
+local function rootProjectHasVitestDependency()
+  local path = rootPackageJson
+
+  local success, packageJsonContent = pcall(lib.files.read, path)
+  if not success then
+    print("cannot read package.json")
+    return false
+  end
+
+  local parsedPackageJson = vim.json.decode(packageJsonContent)
+
+  if parsedPackageJson["devDependencies"] then
+    for key, _ in pairs(parsedPackageJson["devDependencies"]) do
+      if key == "vitest" then
+        return true
+      end
+    end
+  end
+
+  if parsedPackageJson["dependencies"] then
+    for key, _ in pairs(parsedPackageJson["dependencies"]) do
+      if key == "vitest" then
+        return true
+      end
+    end
+  end
+
+  return false
+end
+
 ---@param path string
 ---@return boolean
 local function hasVitestDependency(path)
@@ -46,7 +79,7 @@ local function hasVitestDependency(path)
     end
   end
 
-  return false
+  return rootProjectHasVitestDependency()
 end
 
 adapter.root = function(path)

--- a/spec-monorepo/apps/todo/package.json
+++ b/spec-monorepo/apps/todo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "todo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/spec-monorepo/apps/todo/todo.test.tsx
+++ b/spec-monorepo/apps/todo/todo.test.tsx
@@ -1,0 +1,1 @@
+test('monorepo app test file',()=>{})

--- a/spec-monorepo/package.json
+++ b/spec-monorepo/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "spec-monorepo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "vitest": "^1.3.0"
+  }
+}

--- a/spec-monorepo/packages/example/package.json
+++ b/spec-monorepo/packages/example/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/spec-monorepo/pnpm-workspace.yaml
+++ b/spec-monorepo/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -23,7 +23,17 @@ describe("adapter enabled", function()
 end)
 
 describe("is_test_file", function()
+  local original_dir
+  before_each(function()
+    original_dir = vim.api.nvim_eval("getcwd()")
+  end)
+
+  after_each(function()
+    vim.api.nvim_set_current_dir(original_dir)
+  end)
+
   async.it("matches vitest files", function()
+    vim.api.nvim_set_current_dir("./spec")
     assert.is.truthy(plugin.is_test_file("./spec/basic.test.ts"))
   end)
 
@@ -36,10 +46,12 @@ describe("is_test_file", function()
   end)
 
   async.it("does not match test in repo with jest", function()
+    vim.api.nvim_set_current_dir("./spec-jest")
     assert.is.falsy(plugin.is_test_file("./spec-jest/basic.test.ts"))
   end)
 
   async.it("matches vitest files in monorepo", function()
+    vim.api.nvim_set_current_dir("./spec-monorepo")
     assert.is.truthy(plugin.is_test_file("./spec-monorepo/packages/example/basic.test.ts"))
     assert.is.truthy(plugin.is_test_file("./spec-monorepo/apps/todo/todo.test.tsx"))
   end)


### PR DESCRIPTION
In monorepo setup you typically have multiple package.json files and it's common that a dependency like vitest is only defined in the root. As reported in #30 and #23 this is not currently supported.

This fix seems to be working for my Nx monorepo setup. Additionally I had to change the vitest command:

```lua
require("neotest-vitest")({
  vitestCommand = "npx vitest",
})
```

I copied the solution pretty much as-is from [neotest-jest](https://github.com/nvim-neotest/neotest-jest/pull/64) so all glory to guivazcabral.