### PR TITLE
feat: Handle vitest dependency in workspace package

### DIFF
--- a/spec-monorepo-no-root-dep/apps/todo/package.json
+++ b/spec-monorepo-no-root-dep/apps/todo/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "todo",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/spec-monorepo-no-root-dep/apps/todo/todo.test.tsx
+++ b/spec-monorepo-no-root-dep/apps/todo/todo.test.tsx
@@ -1,0 +1,1 @@
+test('monorepo app test file',()=>{})

--- a/spec-monorepo-no-root-dep/package.json
+++ b/spec-monorepo-no-root-dep/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "spec-monorepo-no-root-dep",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/spec-monorepo-no-root-dep/packages/example/package.json
+++ b/spec-monorepo-no-root-dep/packages/example/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC"
+}

--- a/spec-monorepo-no-root-dep/pnpm-workspace.yaml
+++ b/spec-monorepo-no-root-dep/pnpm-workspace.yaml
@@ -1,0 +1,3 @@
+packages:
+  - "apps/*"
+  - "packages/*"

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -20,6 +20,10 @@ describe("adapter enabled", function()
   async.it("enable adapter for monorepo with vitest at root", function()
     assert.Not.Nil(plugin.root("./spec-monorepo"))
   end)
+
+  async.it("enable adapter for monorepo with vitest in workspace package", function()
+    assert.Not.Nil(plugin.root("./spec-monorepo-no-root-dep"))
+  end)
 end)
 
 describe("is_test_file", function()


### PR DESCRIPTION
In a monorepo where tests are managed in a package, the root package.json is unlikely to have `vitest` as a dependency.
This handles that case by parsing each workspace's package.json looking for a `vitest` dependency.