### PR TITLE
📝 Improve lazy.nvim install syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,14 @@ Credits to [neotest-jest](https://github.com/haydenmeade/neotest-jest)
 {
   "nvim-neotest/neotest",
   dependencies = {
-    ...,
     "marilari88/neotest-vitest",
   },
-  config = function()
-    require("neotest").setup({
-      ...,
-      adapters = {
-        require("neotest-vitest"),
-      }
-    })
-  end,
+  opts = {
+    adapters = {
+      ["neotest-vitest"] = {},
+    },
+  },
+
 }
 ```
 
@@ -57,6 +54,7 @@ Make sure you have Treesitter installed with the right language parser installed
 ```
 
 ## Configuration
+
 ```lua
 {
   "nvim-neotest/neotest",
@@ -133,9 +131,9 @@ end
 ```lua
 
 vim.api.nvim_set_keymap(
-    "n", 
-    "<leader>twr", 
-    "<cmd>lua require('neotest').run.run({ vitestCommand = 'vitest --watch' })<cr>", 
+    "n",
+    "<leader>twr",
+    "<cmd>lua require('neotest').run.run({ vitestCommand = 'vitest --watch' })<cr>",
     {desc = "Run Watch"}
 )
 


### PR DESCRIPTION
I have been having difficulty getting neotest-vitest to work nicely with [LazyVim](https://www.lazyvim.org/).

After much experimentation, what I'm proposing in this PR works and ensures other adaptors configured separately (like neotest-go) work as well.

Hopefully this helps someone else, if I set what was mentioned in the README right now broke my other adaptor configurations.