### PR TITLE
Allow user is_test_file option to fully control over file check

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -456,9 +456,8 @@ setmetatable(adapter, {
     end
 
     if is_callable(opts.is_test_file) then
-      local is_test_file = adapter.is_test_file
       adapter.is_test_file = function(file_path)
-        return is_test_file(file_path) and opts.is_test_file(file_path)
+        return hasVitestDependency(file_path) and opts.is_test_file(file_path)
       end
     end
 


### PR DESCRIPTION
Currently built-in `is _test_file` function is used before the provided function, that does not allow to run tests on any file that does not match default patterns. For example, it's not possible to run a test for `integration.ts`.
The fix runs a custom check for all files on a project.