### PR TITLE
Quote wildcard for all testNamePattern

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -321,7 +321,7 @@ function adapter.build_spec(args)
   end
 
   local pos = args.tree:data()
-  local testNamePattern = ".*"
+  local testNamePattern = "'.*'"
 
   if pos.type == "test" then
     testNamePattern = escapeTestPattern(pos.name) .. "$"


### PR DESCRIPTION
Some shells (looking at you zsh) try to expand wildcards on the command line before invoking the underlying command resulting in no tests run when targeting a whole file. Quoting the pattern lets it get handled directly by vitest.