### PR TITLE
feat: improve monorepo support

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -49,15 +49,14 @@ end
 ---@param path string
 ---@return boolean
 local function hasVitestDependency(path)
-  local nodeRootPath = lib.files.match_root_pattern("package.json")(path)
+  local rootPath = lib.files.match_root_pattern("package.json")(path)
 
-  if not nodeRootPath then
+  if not rootPath then
     return false
   end
 
-  local nodeRootSuccess, nodeRootPackageJsonContent =
-    pcall(lib.files.read, nodeRootPath .. "/package.json")
-  if not nodeRootSuccess then
+  local success, rootPackageJsonContent = pcall(lib.files.read, rootPath .. "/package.json")
+  if not success then
     print("cannot read package.json")
     return false
   end
@@ -66,15 +65,15 @@ local function hasVitestDependency(path)
   local hasRootMonorepoVitestDependency = false
 
   -- only check the git root's package.json if it's different (e.g. in monorepos)
-  if nodeRootPath ~= gitRootPath then
-    local gitRootSuccess, gitRootPackageJsonContent =
+  if rootPath ~= gitRootPath then
+    local monorepoSuccess, monorepoRootPackageJsonContent =
       pcall(lib.files.read, gitRootPath .. "/package.json")
-    if gitRootSuccess then
-      hasRootMonorepoVitestDependency = hasVitestDependencyInJson(gitRootPackageJsonContent)
+    if monorepoSuccess then
+      hasRootMonorepoVitestDependency = hasVitestDependencyInJson(monorepoRootPackageJsonContent)
     end
   end
 
-  return hasVitestDependencyInJson(nodeRootPackageJsonContent)
+  return hasVitestDependencyInJson(rootPackageJsonContent)
     or hasRootProjectVitestDependency()
     or hasRootMonorepoVitestDependency
 end

--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -55,7 +55,7 @@ local function hasVitestDependency(path)
     return false
   end
 
-  local success, rootPackageJsonContent = pcall(lib.files.read, rootPath .. "/package.json")
+  local success, packageJsonContent = pcall(lib.files.read, rootPath .. "/package.json")
   if not success then
     print("cannot read package.json")
     return false
@@ -73,7 +73,7 @@ local function hasVitestDependency(path)
     end
   end
 
-  return hasVitestDependencyInJson(rootPackageJsonContent)
+  return hasVitestDependencyInJson(packageJsonContent)
     or hasRootProjectVitestDependency()
     or hasRootMonorepoVitestDependency
 end
@@ -167,8 +167,8 @@ end
 ---@param path string
 ---@return string
 local function getVitestCommand(path)
-  local nodeRootPath = util.find_node_modules_ancestor(path)
-  local vitestBinary = util.path.join(nodeRootPath, "node_modules", ".bin", "vitest")
+  local rootPath = util.find_node_modules_ancestor(path)
+  local vitestBinary = util.path.join(rootPath, "node_modules", ".bin", "vitest")
 
   if util.path.exists(vitestBinary) then
     return vitestBinary

--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -65,7 +65,7 @@ local function hasVitestDependency(path)
   local hasRootMonorepoVitestDependency = false
 
   -- only check the git root's package.json if it's different (e.g. in monorepos)
-  if rootPath ~= gitRootPath then
+  if gitRootPath and rootPath ~= gitRootPath then
     local monorepoSuccess, monorepoRootPackageJsonContent =
       pcall(lib.files.read, gitRootPath .. "/package.json")
     if monorepoSuccess then
@@ -175,10 +175,11 @@ local function getVitestCommand(path)
   end
 
   local gitRootPath = util.find_git_ancestor(path)
-  vitestBinary = util.path.join(gitRootPath, "node_modules", ".bin", "vitest")
-
-  if util.path.exists(vitestBinary) then
-    return vitestBinary
+  if gitRootPath then
+    vitestBinary = util.path.join(gitRootPath, "node_modules", ".bin", "vitest")
+    if util.path.exists(vitestBinary) then
+      return vitestBinary
+    end
   end
 
   return "vitest"

--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -84,7 +84,7 @@ function adapter.is_test_file(file_path)
     is_test_file = true
   end
 
-  for _, x in ipairs({ "spec", "test" }) do
+  for _, x in ipairs({ "e2e", "spec", "test" }) do
     for _, ext in ipairs({ "js", "jsx", "coffee", "ts", "tsx" }) do
       if string.match(file_path, "%." .. x .. "%." .. ext .. "$") then
         is_test_file = true
@@ -153,8 +153,15 @@ end
 ---@param path string
 ---@return string
 local function getVitestCommand(path)
-  local rootPath = util.find_node_modules_ancestor(path)
-  local vitestBinary = util.path.join(rootPath, "node_modules", ".bin", "vitest")
+  local nodeRootPath = util.find_node_modules_ancestor(path)
+  local vitestBinary = util.path.join(nodeRootPath, "node_modules", ".bin", "vitest")
+
+  if util.path.exists(vitestBinary) then
+    return vitestBinary
+  end
+
+  local gitRootPath = util.find_git_ancestor(path)
+  vitestBinary = util.path.join(gitRootPath, "node_modules", ".bin", "vitest")
 
   if util.path.exists(vitestBinary) then
     return vitestBinary

--- a/lua/neotest-vitest/util.lua
+++ b/lua/neotest-vitest/util.lua
@@ -171,6 +171,14 @@ function M.root_pattern(...)
   end
 end
 
+function M.find_git_ancestor(startpath)
+  return M.search_ancestors(startpath, function(path)
+    -- .git is a file when the project is a git worktree or it's a directory if it's a regular project
+    if M.path.is_file(M.path.join(path, ".git")) or M.path.is_dir(M.path.join(path, ".git")) then
+      return path
+    end
+  end)
+end
 function M.find_node_modules_ancestor(startpath)
   return M.search_ancestors(startpath, function(path)
     if M.path.is_dir(M.path.join(path, "node_modules")) then


### PR DESCRIPTION
Sometimes there will be multiple node_modules directories when working in a monorepo. With this change, the node_modules in the repo's root directory will be checked for the vitest binary as a fallback.

I also added `e2e` as a pattern for test file names, which is what my team uses. Let me know if you'd prefer I split that into a separate PR though. Thanks!

Fixes #68