### PR TITLE
feat: Reflect cwd changes in the dependency check

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -15,8 +15,6 @@ local util = require("neotest-vitest.util")
 ---@class neotest.Adapter
 local adapter = { name = "neotest-vitest" }
 
-local rootPackageJson = vim.fn.getcwd() .. "/package.json"
-
 ---@param packageJsonContent string
 ---@return boolean
 local function hasVitestDependencyInJson(packageJsonContent)
@@ -37,9 +35,11 @@ end
 
 ---@return boolean
 local function hasRootProjectVitestDependency()
+  local rootPackageJson = vim.loop.cwd() .. "/package.json"
+
   local success, packageJsonContent = pcall(lib.files.read, rootPackageJson)
   if not success then
-    print("cannot read package.json")
+    print("cannot read package.json, got " .. rootPackageJson)
     return false
   end
 


### PR DESCRIPTION
Hello! My usecase is quite different from what is probably expected from a typical VIM user. I use neovide GUI client, so I always start at cwd '/' which got picked up by this fantastic plugin. When I change `cwd` dynamically, neotest tries to determine whether there are tests again, but this plugin uses precalculated `cwd` property without ever updating it.

I fixed that, and also used `vim.loop.cwd` instead `vim.fn.getcwd` since the latter doesn't allow to be used inside lua coroutine.