### PR TITLE
fix: test results incorrect returned on windows

### DIFF
--- a/lua/neotest-vitest/util.lua
+++ b/lua/neotest-vitest/util.lua
@@ -18,6 +18,14 @@ M.path = (function()
     return path
   end
 
+  local function restore_windows_path(path)
+    if is_windows then
+      path = path:sub(1, 1):upper() .. path:sub(2)
+      path = path:gsub("/", "\\")
+    end
+    return path
+  end
+
   local function exists(filename)
     local stat = uv.fs_stat(filename)
     return stat and stat.type or false
@@ -129,6 +137,7 @@ M.path = (function()
     dirname = dirname,
     join = path_join,
     sanitize = sanitize,
+    restore_windows_path = restore_windows_path,
     traverse_parents = traverse_parents,
     iterate_parents = iterate_parents,
     is_descendant = is_descendant,
@@ -249,6 +258,7 @@ function M.parsed_json_to_results(data, output_file, consoleOut)
 
   for _, testResult in pairs(data.testResults) do
     local testFn = testResult.name
+    testFn = M.path.restore_windows_path(testFn)
 
     for _, assertionResult in pairs(testResult.assertionResults) do
       local status, name = assertionResult.status, assertionResult.title

--- a/lua/neotest-vitest/util.lua
+++ b/lua/neotest-vitest/util.lua
@@ -20,7 +20,9 @@ M.path = (function()
 
   local function restore_windows_path(path)
     if is_windows then
-      path = path:sub(1, 1):upper() .. path:sub(2)
+      if path:match("^[a-zA-Z]:") then
+        path = path:sub(1, 1):upper() .. path:sub(2)
+      end
       path = path:gsub("/", "\\")
     end
     return path


### PR DESCRIPTION
I am using neovim in Windows,
when I use neotest-vitest, neotest shows all tests as failed but the output summary says passed
I found the issue was the function name, on windows, this needs to be with \\ instead of /
this made neotest not recognize the test result and returning failed

Other people also have this issue, this was mentioned in #48 