### PR TITLE
Replace deprecated vim.tbl_flatten with vim.iter.flatten

### DIFF
--- a/lua/neotest-vitest/util.lua
+++ b/lua/neotest-vitest/util.lua
@@ -65,7 +65,7 @@ M.path = (function()
   end
 
   local function path_join(...)
-    return table.concat(vim.tbl_flatten({ ... }), "/")
+    return table.concat(vim.iter({ ... }):flatten():totable(), "/")
   end
 
   -- Traverse the path calling cb along the way.

--- a/lua/neotest-vitest/util.lua
+++ b/lua/neotest-vitest/util.lua
@@ -156,7 +156,7 @@ function M.search_ancestors(startpath, func)
 end
 
 function M.root_pattern(...)
-  local patterns = vim.tbl_flatten({ ... })
+  local patterns = vim.iter({ ... }):flatten():totable()
   local function matcher(path)
     for _, pattern in ipairs(patterns) do
       for _, p in ipairs(vim.fn.glob(M.path.join(path, pattern), true, true)) do


### PR DESCRIPTION
Due to recent deprecations in 0.12 and upcoming removal of vim.tbl_flatten in neovim 0.13
#79
