### PR TITLE
feat: forward extra args to vitest runner

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -313,6 +313,8 @@ function adapter.build_spec(args)
     vim.fs.normalize(pos.path),
   })
 
+  vim.list_extend(command, args.extra_args or {})
+
   local cwd = getCwd(pos.path)
 
   -- creating empty file for streaming results


### PR DESCRIPTION
Enables forwarding extra_args from `neotest.run` to vitest. Personally, I find it useful to disable test timeouts when debugging tests:

```ts
require("neotest").run.run({ strategy = "dap", extra_args = { "--testTimeout=0" } })
```