### PR TITLE
feat: default to vitest config dir or root dir if cwd not provided

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -265,7 +265,7 @@ end
 ---@param path string
 ---@return string|nil
 local function getCwd(path)
-  return nil
+  return vitestConfigPattern(path) or util.find_node_modules_ancestor(path)
 end
 
 ---@param args neotest.RunArgs


### PR DESCRIPTION
This makes it so the config's include / exclude options will work as expected when running it from say, a monorepo root.
