### PR TITLE
feat: support @effect/vitest `layer` syntax

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -136,6 +136,13 @@ function adapter.discover_positions(path)
       )
       arguments: (arguments (string (string_fragment) @namespace.name) (arrow_function))
     )) @namespace.definition
+    ; Matches: `layer(...)('context', () => ...)` (@effect/vitest syntax)
+    ((call_expression
+      function: (call_expression
+        function: (identifier) @func_name (#eq? @func_name "layer")
+      )
+      arguments: (arguments (string (string_fragment) @namespace.name) (arrow_function))
+    )) @namespace.definition
 
     ; -- Tests --
     ; Matches: `test('test') / it('test')`


### PR DESCRIPTION
[@effect/vitest](https://github.com/Effect-TS/effect/tree/main/packages/vitest) provides a `layer` function that looks like this:
```ts
it.layer(TestLayer)("My Test Layer", it => {
  it.effect("should work", () => {})
})
```

This PR adds to the positions query so the namespace definition for `layer` is recognized and the tests inside it are discovered.

If this is _too specific_, another option is to add a new config value that lets the user expand the query themselves. Something like:

```lua
require("neotest-vitest")({
  extra_positions_query = [[
  ; Matches: `layer(...)('context', () => ...)` (@effect/vitest syntax)
  ((call_expression
    function: (call_expression
      function: (identifier) @func_name (#eq? @func_name "layer")
    )
    arguments: (arguments (string (string_fragment) @namespace.name) (arrow_function))
  )) @namespace.definition
  ]],
}),
```
