### PR TITLE
Allow passing a custom DAP strategy configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,24 @@ filter_dir = function(name, rel_path, root)
 end
 ```
 
+### Custom debug configuration
+
+Use the `strategy_config` option to override / extend the default [nvim-dap](https://github.com/mfussenegger/nvim-dap) configuration.
+
+```lua
+---Disable test timeouts during debug sessions
+---@param default table The default DAP config provided by neotest-vitest
+---@param args neotest.RunArgs
+---@return table
+strategy_config = function(default, args)
+  if args.strategy == "dap" then
+    return vim.tbl_deep_extend("force", default, {
+        args = vim.list_extend(vim.list_slice(default.args), { "--testTimeout=0" })
+    })
+  end
+end
+```
+
 ### Watch mode mappings
 
 ```lua

--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -11,6 +11,7 @@ local util = require("neotest-vitest.util")
 ---@field cwd? string|fun(): string
 ---@field filter_dir? fun(name: string, relpath: string, root: string): boolean
 ---@field is_test_file? fun(file_path: string): boolean
+---@field strategy_config? table<string, unknown>|fun(default: table, args: neotest.RunArgs): table<string, unknown>
 
 ---@class neotest.Adapter
 local adapter = { name = "neotest-vitest" }
@@ -245,7 +246,7 @@ local function escapeTestPattern(s)
   )
 end
 
-local function get_strategy_config(strategy, command, cwd)
+local function getDefaultStrategyConfig(strategy, command, cwd)
   local config = {
     dap = function()
       return {
@@ -273,6 +274,10 @@ end
 ---@return string|nil
 local function getCwd(path)
   return vitestConfigPattern(path) or util.find_node_modules_ancestor(path)
+end
+
+local function getStrategyConfig(defaultStrategyConfig, args)
+  return defaultStrategyConfig
 end
 
 ---@param args neotest.RunArgs
@@ -363,7 +368,7 @@ function adapter.build_spec(args)
         return util.parsed_json_to_results(parsed, results_path, nil)
       end
     end,
-    strategy = get_strategy_config(args.strategy, command, cwd),
+    strategy = getStrategyConfig(getDefaultStrategyConfig(args.strategy, command, cwd) or {}, args),
     env = getEnv(args[2] and args[2].env or {}),
   }
 end
@@ -431,6 +436,14 @@ setmetatable(adapter, {
     elseif opts.cwd then
       getCwd = function()
         return opts.cwd
+      end
+    end
+
+    if is_callable(opts.strategy_config) then
+      getStrategyConfig = opts.strategy_config
+    elseif opts.strategy_config then
+      getStrategyConfig = function()
+        return opts.strategy_config
       end
     end
 


### PR DESCRIPTION
Ported from https://github.com/nvim-neotest/neotest-jest/pull/39.

Allows overriding or extending the default DAP strategy in the plugin's configuration.