### PR TITLE
Also detect vitest when installed as dependency

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -23,7 +23,7 @@ local function hasVitestDependencyInJson(packageJsonContent)
   for _, dependencyType in ipairs({ "dependencies", "devDependencies" }) do
     if parsedPackageJson[dependencyType] then
       for key, _ in pairs(parsedPackageJson[dependencyType]) do
-        if key == "vitest" then
+        if key == "vitest" or key == "@vitest/ui" or key == "@vitest/coverage-v8" then
           return true
         end
       end


### PR DESCRIPTION
We install `vitest` by installing `@vitest/ui` and/or `@vitest/coverage-v8`. This case was previously not detected by the plugin so we got the 'no tests found' error.