### PR TITLE
fix: ensure watch flag is only passed once

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -312,13 +312,23 @@ function adapter.build_spec(args)
   end
 
   vim.list_extend(command, {
-    "--watch=false",
     "--reporter=verbose",
     "--reporter=json",
     "--outputFile=" .. results_path,
     "--testNamePattern=" .. testNamePattern,
     vim.fs.normalize(pos.path),
   })
+
+  if
+    not vim.list_contains(command, "-w")
+    and not vim.list_contains(command, "--watch")
+    and not vim.list_contains(command, "--watch=true")
+    and not vim.list_contains(command, "--watch=false")
+  then
+    vim.list_extend(command, {
+      "--watch=false",
+    })
+  end
 
   vim.list_extend(command, args.extra_args or {})
 

--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -311,14 +311,6 @@ function adapter.build_spec(args)
     table.insert(command, "--config=" .. config)
   end
 
-  vim.list_extend(command, {
-    "--reporter=verbose",
-    "--reporter=json",
-    "--outputFile=" .. results_path,
-    "--testNamePattern=" .. testNamePattern,
-    vim.fs.normalize(pos.path),
-  })
-
   if
     not vim.list_contains(command, "-w")
     and not vim.list_contains(command, "--watch")
@@ -329,6 +321,14 @@ function adapter.build_spec(args)
       "--watch=false",
     })
   end
+
+  vim.list_extend(command, {
+    "--reporter=verbose",
+    "--reporter=json",
+    "--outputFile=" .. results_path,
+    "--testNamePattern=" .. testNamePattern,
+    vim.fs.normalize(pos.path),
+  })
 
   vim.list_extend(command, args.extra_args or {})
 

--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -311,6 +311,16 @@ function adapter.build_spec(args)
     table.insert(command, "--config=" .. config)
   end
 
+  vim.list_extend(command, {
+    "--reporter=verbose",
+    "--reporter=json",
+    "--outputFile=" .. results_path,
+    "--testNamePattern=" .. testNamePattern,
+    vim.fs.normalize(pos.path),
+  })
+
+  vim.list_extend(command, args.extra_args or {})
+
   if
     not vim.list_contains(command, "-w")
     and not vim.list_contains(command, "--watch")
@@ -321,16 +331,6 @@ function adapter.build_spec(args)
       "--watch=false",
     })
   end
-
-  vim.list_extend(command, {
-    "--reporter=verbose",
-    "--reporter=json",
-    "--outputFile=" .. results_path,
-    "--testNamePattern=" .. testNamePattern,
-    vim.fs.normalize(pos.path),
-  })
-
-  vim.list_extend(command, args.extra_args or {})
 
   local cwd = getCwd(pos.path)
 

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -257,14 +257,14 @@ describe("build_spec", function()
     local expected_command = {
       "vitest",
       "--config=./spec/vite.config.ts",
-      "--watch=false",
       "--reporter=verbose",
       "--reporter=json",
       "--outputFile=/tmp/foo.json",
       "--testNamePattern=.*",
-      -- "spec/basic.test.ts",
+      "spec/basic.test.ts",
+      "--watch=false",
     }
-    assert.is.same(expected_command, vim.list_slice(spec.command, 0, #spec.command - 1))
+    assert.is.same(expected_command, spec.command)
     assert.is.truthy(spec.context.file)
     assert.is.truthy(spec.context.results_path)
   end)
@@ -281,16 +281,28 @@ describe("build_spec", function()
       "vitest",
       "--watch",
       "--config=./spec/vite.config.ts",
-      "--watch=false",
       "--reporter=verbose",
       "--reporter=json",
       "--outputFile=/tmp/foo.json",
       "--testNamePattern=.*",
-      -- "spec/basic.test.ts",
+      "spec/basic.test.ts",
     }
-    assert.is.same(expected_command, vim.list_slice(spec.command, 0, #spec.command - 1))
+    assert.is.same(expected_command, spec.command)
+    assert.is.falsy(vim.list_contains(spec.command, "--watch=false"))
     assert.is.truthy(spec.context.file)
     assert.is.truthy(spec.context.results_path)
+  end)
+
+  async.it("builds command passed watch flag via extra_args", function()
+    local positions = plugin.discover_positions("./spec/basic.test.ts"):to_list()
+    local tree = Tree.from_list(positions, function(pos)
+      return pos.id
+    end)
+    local spec = plugin.build_spec({ tree = tree, extra_args = { "--watch" } })
+
+    assert.is.truthy(spec)
+    assert.is.falsy(vim.list_contains(spec.command, "--watch=false"))
+    assert.is.truthy(vim.list_contains(spec.command, "--watch"))
   end)
 
   async.it("builds command for namespace", function()
@@ -306,14 +318,14 @@ describe("build_spec", function()
     local expected_command = {
       "vitest",
       "--config=./spec/vite.config.ts",
-      "--watch=false",
       "--reporter=verbose",
       "--reporter=json",
       "--outputFile=/tmp/foo.json",
       "--testNamePattern=^\\s?describe\\sarrow\\sfunction",
-      -- "spec/basic.test.ts",
+      "spec/basic.test.ts",
+      "--watch=false",
     }
-    assert.is.same(expected_command, vim.list_slice(spec.command, 0, #spec.command - 1))
+    assert.is.same(expected_command, spec.command)
     assert.is.truthy(spec.context.file)
     assert.is.truthy(spec.context.results_path)
   end)
@@ -331,14 +343,14 @@ describe("build_spec", function()
     local expected_command = {
       "vitest",
       "--config=./spec/config/vite/vite.config.ts",
-      "--watch=false",
       "--reporter=verbose",
       "--reporter=json",
       "--outputFile=/tmp/foo.json",
       "--testNamePattern=^\\s?1$",
-      -- "spec/config/vite/basic.test.ts",
+      "spec/config/vite/basic.test.ts",
+      "--watch=false",
     }
-    assert.is.same(expected_command, vim.list_slice(spec.command, 0, #spec.command - 1))
+    assert.is.same(expected_command, spec.command)
     assert.is.truthy(spec.context.file)
     assert.is.truthy(spec.context.results_path)
   end)
@@ -356,14 +368,14 @@ describe("build_spec", function()
     local expected_command = {
       "vitest",
       "--config=./spec/config/vitest/vitest.config.ts",
-      "--watch=false",
       "--reporter=verbose",
       "--reporter=json",
       "--outputFile=/tmp/foo.json",
       "--testNamePattern=^\\s?1$",
-      -- "spec/config/vitest/basic.test.ts",
+      "spec/config/vitest/basic.test.ts",
+      "--watch=false",
     }
-    assert.is.same(expected_command, vim.list_slice(spec.command, 0, #spec.command - 1))
+    assert.is.same(expected_command, spec.command)
     assert.is.truthy(spec.context.file)
     assert.is.truthy(spec.context.results_path)
   end)


### PR DESCRIPTION
Check to see if the user passed the watch flag to `vitestCommand` or `extra_args` before adding `--watch=false`.

Resolves #53