### PR TITLE
feat: support configurable vitest reporters

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,12 @@ Make sure you have Treesitter installed with the right language parser installed
 }
 ```
 
+You can also override reporters for a single run:
+
+```lua
+require("neotest").run.run({ reporters = { "minimal" } })
+```
+
 ### Stricter file parsing to determine test files
 
 Use `is_test_file` option to add a custom criteria for test file discovery.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,9 @@ Make sure you have Treesitter installed with the right language parser installed
       ...,
       adapters = {
         require("neotest-vitest") {
+          -- Override Vitest terminal reporters. The JSON reporter is always added for result parsing.
+          reporters = { "minimal" },
+
           -- Filter directories when searching for test files. Useful in large projects (see Filter directories notes).
           filter_dir = function(name, rel_path, root)
             return name ~= "node_modules"

--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -303,7 +303,7 @@ local function withJsonReporter(reporters)
   return vim.list_extend(vim.deepcopy(reporters), { "json" })
 end
 
----@param args neotest.RunArgs
+---@param args neotest.RunArgs|{ reporters?: string|string[] }
 ---@return neotest.RunSpec | nil
 function adapter.build_spec(args)
   local results_path = async.fn.tempname() .. ".json"
@@ -343,7 +343,7 @@ function adapter.build_spec(args)
     "--watch=false",
   })
 
-  for _, reporter in ipairs(getReporters()) do
+  for _, reporter in ipairs(args.reporters and withJsonReporter(args.reporters) or getReporters()) do
     table.insert(command, "--reporter=" .. reporter)
   end
 

--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -9,6 +9,7 @@ local util = require("neotest-vitest.util")
 ---@field vitestConfigFile? string|fun(): string
 ---@field env? table<string, string>|fun(): table<string, string>
 ---@field cwd? string|fun(): string
+---@field reporters? string|string[]|fun(): string|string[]
 ---@field filter_dir? fun(name: string, relpath: string, root: string): boolean
 ---@field is_test_file? fun(file_path: string): boolean
 
@@ -275,6 +276,33 @@ local function getCwd(path)
   return vitestConfigPattern(path) or util.find_node_modules_ancestor(path)
 end
 
+---@return string[]
+local function getReporters()
+  return { "verbose", "json" }
+end
+
+---@param reporters string|string[]
+---@return string[]
+local function withJsonReporter(reporters)
+  if type(reporters) == "string" then
+    reporters = { reporters }
+  end
+
+  local hasJsonReporter = false
+  for _, reporter in ipairs(reporters) do
+    if reporter == "json" then
+      hasJsonReporter = true
+      break
+    end
+  end
+
+  if hasJsonReporter then
+    return reporters
+  end
+
+  return vim.list_extend(vim.deepcopy(reporters), { "json" })
+end
+
 ---@param args neotest.RunArgs
 ---@return neotest.RunSpec | nil
 function adapter.build_spec(args)
@@ -313,8 +341,13 @@ function adapter.build_spec(args)
 
   vim.list_extend(command, {
     "--watch=false",
-    "--reporter=verbose",
-    "--reporter=json",
+  })
+
+  for _, reporter in ipairs(getReporters()) do
+    table.insert(command, "--reporter=" .. reporter)
+  end
+
+  vim.list_extend(command, {
     "--outputFile=" .. results_path,
     "--testNamePattern=" .. testNamePattern,
     vim.fs.normalize(pos.path),
@@ -421,6 +454,16 @@ setmetatable(adapter, {
     elseif opts.cwd then
       getCwd = function()
         return opts.cwd
+      end
+    end
+
+    if is_callable(opts.reporters) then
+      getReporters = function()
+        return withJsonReporter(opts.reporters())
+      end
+    elseif opts.reporters then
+      getReporters = function()
+        return withJsonReporter(opts.reporters)
       end
     end
 

--- a/tests/init_options_spec.lua
+++ b/tests/init_options_spec.lua
@@ -54,4 +54,30 @@ describe("build_spec with override", function()
       { override = "override", adapter_override = true, spec_override = true }
     )
   end)
+
+  async.it("builds command with custom reporters", function()
+    local plugin = require("neotest-vitest")({
+      vitestCommand = binary_override,
+      vitestConfigFile = config_override,
+      reporters = { "minimal" },
+    })
+
+    local positions = plugin.discover_positions("./spec/basic.test.ts"):to_list()
+    local tree = Tree.from_list(positions, function(pos)
+      return pos.id
+    end)
+    local spec = plugin.build_spec({ tree = tree })
+
+    assert.is.truthy(spec)
+
+    local command = spec.command
+    assert.is.truthy(command)
+    assert.contains(command, "--reporter=minimal")
+    assert.contains(command, "--reporter=json")
+    assert.is.falsy(vim.tbl_contains(command, "--reporter=verbose"))
+
+    require("neotest-vitest")({
+      reporters = { "verbose", "json" },
+    })
+  end)
 end)

--- a/tests/init_options_spec.lua
+++ b/tests/init_options_spec.lua
@@ -80,4 +80,30 @@ describe("build_spec with override", function()
       reporters = { "verbose", "json" },
     })
   end)
+
+  async.it("builds command with run reporters", function()
+    local plugin = require("neotest-vitest")({
+      vitestCommand = binary_override,
+      vitestConfigFile = config_override,
+      reporters = { "verbose" },
+    })
+
+    local positions = plugin.discover_positions("./spec/basic.test.ts"):to_list()
+    local tree = Tree.from_list(positions, function(pos)
+      return pos.id
+    end)
+    local spec = plugin.build_spec({ tree = tree, reporters = { "minimal" } })
+
+    assert.is.truthy(spec)
+
+    local command = spec.command
+    assert.is.truthy(command)
+    assert.contains(command, "--reporter=minimal")
+    assert.contains(command, "--reporter=json")
+    assert.is.falsy(vim.tbl_contains(command, "--reporter=verbose"))
+
+    require("neotest-vitest")({
+      reporters = { "verbose", "json" },
+    })
+  end)
 end)


### PR DESCRIPTION
Adds `reporters` option to configure Vitest terminal reporters.

- supports adapter-level reporters config
- supports per-run reporters override
- always keeps `json` reporter for neotest result parsing
- adds tests and README examples