### PR TITLE
chore(ci): bump CI to Neovim 0.12 + nvim-treesitter main API

### DIFF
--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -28,7 +28,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        neovim_version: ['v0.10.0', 'nightly']
+        neovim_version: ['v0.12.3', 'nightly']
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/workflow.yaml
+++ b/.github/workflows/workflow.yaml
@@ -39,6 +39,13 @@ jobs:
           neovim: true
           version: ${{ matrix.neovim_version }}
 
+      - name: Install tree-sitter CLI
+        run: |
+          curl -fsSL https://github.com/tree-sitter/tree-sitter/releases/download/v0.26.10/tree-sitter-linux-x64.gz \
+            | gunzip > /usr/local/bin/tree-sitter
+          chmod +x /usr/local/bin/tree-sitter
+          tree-sitter --version
+
       - name: Run tests
         run: |
           nvim --version

--- a/tests/minimal_init.vim
+++ b/tests/minimal_init.vim
@@ -5,11 +5,12 @@ set rtp+=.testdeps/neotest
 set rtp+=.testdeps/nvim-nio
 
 lua <<EOF
-require'nvim-treesitter.configs'.setup {
-  -- Make sure we have javascript and typescript treesitter parsers installed so tests can run
-  ensure_installed = { "javascript", "typescript" },
-  sync_install = true
-}
+-- Install javascript and typescript treesitter parsers synchronously so tests can run.
+-- Uses the nvim-treesitter `main` branch API (requires Neovim 0.12+); the legacy
+-- `nvim-treesitter.configs` module was removed when the default branch became the
+-- incompatible rewrite on 2026-04-03.
+require('nvim-treesitter').setup {}
+require('nvim-treesitter').install({ 'javascript', 'typescript' }):wait(300000)
 EOF
 
 runtime! plugin/plenary.vim


### PR DESCRIPTION
## Why

CI has been red on `main` (and every PR since ~May 2026, including #94) with:

```
.../vim/treesitter/language.lua:107: no parser for 'typescript' language
```

## Root cause

`scripts/test` clones `nvim-treesitter`'s default branch. On **2026-04-03** the repo's `main` branch became an archived, **incompatible rewrite** that:

- removed the legacy `require('nvim-treesitter.configs')` module (used by `tests/minimal_init.vim` to install the `javascript`/`typescript` parsers), and
- requires **Neovim 0.12+**.

So no JS/TS parsers were ever installed, and every test that calls `discover_positions` (12 of 20 in the unit suite) blew up at `vim.treesitter.language.add`.

## Changes

- `tests/minimal_init.vim` — replace the removed `configs.setup({ ensure_installed, sync_install })` with the new documented synchronous-install API: `require('nvim-treesitter').install({ ... }):wait(300000)`.
- `.github/workflows/workflow.yaml` — bump the matrix from `v0.10.0`/`nightly` to `v0.12.3`/`nightly` (latest stable, released 2026-06-10).

Plugin source (`lua/neotest-vitest/{init,util}.lua`) is untouched: `vim.loop` deprecations still work on 0.12, and `vim.iter`/`vim.list_contains` are fine at the new floor.

## Follow-up

Once this lands and `main` is green, @benelan can rebase #94 (`fix-watch-mode`) onto `main` so that PR picks up the fixed infra.