### PR TITLE
fix: reported error line points to test definition instead of failed assertion

### DIFF
--- a/lua/neotest-vitest/util.lua
+++ b/lua/neotest-vitest/util.lua
@@ -244,6 +244,15 @@ function M.cleanAnsi(s)
     :gsub("\x1b%[%d+;%d+m", "")
     :gsub("\x1b%[%d+m", "")
 end
+
+function M.findErrorPosition(file, errStr)
+  -- Look for: /path/to/file.js:123:987
+  local regexp = file:gsub("([^%w])", "%%%1") .. "%:(%d+)%:(%d+)"
+  local _, _, errLine, errColumn = errStr:find(regexp)
+
+  return errLine, errColumn
+end
+
 function M.parsed_json_to_results(data, output_file, consoleOut)
   local tests = {}
 
@@ -285,9 +294,19 @@ function M.parsed_json_to_results(data, output_file, consoleOut)
         for i, failMessage in ipairs(assertionResult.failureMessages) do
           local msg = M.cleanAnsi(failMessage)
 
+          local errorLine, errorColumn = M.findErrorPosition(testFn, msg)
+
           errors[i] = {
-            line = (assertionResult.location and assertionResult.location.line - 1 or nil),
-            column = (assertionResult.location and assertionResult.location.column or nil),
+            line = (
+              (errorLine and errorLine - 1)
+              or (assertionResult.location and assertionResult.location.line - 1)
+              or nil
+            ),
+            column = (
+              (errorColumn and errorColumn - 1)
+              or (assertionResult.location and assertionResult.location.column)
+              or nil
+            ),
             message = msg,
           }
 

--- a/tests/util_spec.lua
+++ b/tests/util_spec.lua
@@ -1,6 +1,75 @@
 local util = require("neotest-vitest.util")
 
 describe("parse json reporter to result", function()
+  it("failing test with stack trace", function()
+    local json = {
+      success = true,
+      testResults = {
+        {
+          assertionResults = {
+            {
+              ancestorTitles = { "", "describe arrow function" },
+              fullName = " describe arrow function foo",
+              status = "skipped",
+              title = "foo",
+              failureMessages = {},
+            },
+            {
+              ancestorTitles = { "", "describe arrow function" },
+              duration = 3,
+              failureMessages = {
+                "expected true to equal false\n  at /neotest-vitest/spec/basic.test.ts:9:25",
+              },
+              fullName = " describe arrow function bar(error)",
+              location = {
+                column = 43,
+                line = 8,
+              },
+              status = "failed",
+              title = "bar(error)",
+            },
+            {
+              ancestorTitles = { "", "describe vanilla function" },
+              fullName = " describe vanilla function bar",
+              status = "skipped",
+              title = "bar",
+              failureMessages = {},
+            },
+          },
+
+          name = "spec/basic.test.ts",
+        },
+      },
+    }
+    local result = util.parsed_json_to_results(json, nil, nil)
+    local expected_result = {
+      ["spec/basic.test.ts::describe arrow function::bar(error)"] = {
+        errors = {
+          {
+            column = 24,
+            line = 8,
+            message = "expected true to equal false\n  at /neotest-vitest/spec/basic.test.ts:9:25",
+          },
+        },
+        location = {
+          column = 43,
+          line = 8,
+        },
+        short = "bar(error): failed\nexpected true to equal false\n  at /neotest-vitest/spec/basic.test.ts:9:25",
+        status = "failed",
+      },
+      ["spec/basic.test.ts::describe arrow function::foo"] = {
+        short = "foo: skipped",
+        status = "skipped",
+      },
+      ["spec/basic.test.ts::describe vanilla function::bar"] = {
+        short = "bar: skipped",
+        status = "skipped",
+      },
+    }
+    assert.is.same(expected_result, result)
+  end)
+
   it("test", function()
     local json = {
       success = true,
@@ -52,6 +121,7 @@ describe("parse json reporter to result", function()
     }
     assert.is.same(expected_result, result)
   end)
+
   it("namespace", function()
     local json = {
       success = false,


### PR DESCRIPTION
# Summary

Reported location in both `jest` and `vitest` points to the test definition instead of the location of the assertion that failed. This, makes diagnostics to be wrongly placed.
Example:
<img width="1722" height="100" alt="image" src="https://github.com/user-attachments/assets/851a16a9-4ac3-4e3e-be7f-0371c8f9ca81" />

Taking advantage of the stack trace that can be found in the reported error message, in this PR the diagnostic location is being fixed.
Example:
<img width="565" height="65" alt="image" src="https://github.com/user-attachments/assets/907a1783-7287-4d1c-b33b-583e1c83a066" />

# Changes
- stack trace from error message is being parsed to get the location of the line related to the reported error.
- When error location is found, it's used directly
- When error location is not found, the already defined location is used


# Checklist

- [x] Changes are covered with tests 
