### PR TITLE
feat: support call expressions as the test definition

### DIFF
--- a/lua/neotest-vitest/init.lua
+++ b/lua/neotest-vitest/init.lua
@@ -113,7 +113,7 @@ end
 ---@async
 ---@return neotest.Tree | nil
 function adapter.discover_positions(path)
-  local query = [[
+  local query = [[ ;; query
     ; -- Namespaces --
     ; Matches: `describe('context')`
     ((call_expression
@@ -167,7 +167,19 @@ function adapter.discover_positions(path)
       arguments: (arguments (string (string_fragment) @test.name) (arrow_function))
     )) @test.definition
   ]]
-  query = query .. string.gsub(query, "arrow_function", "function_expression")
+  ---@note This portion of the query lives in its own variable because there's no arrow function to replace
+  local call_expression_query = [[ ; query
+    ;; Matches call expressions as the test definition: `it('can do something with A', TestFactory.build('A'))`
+    ((call_expression
+      function: (identifier) @func_name (#any-of? @func_name "it" "test")
+      arguments: (arguments
+        (string
+          (string_fragment) @test.name)
+        (call_expression)))) @test.definition
+  ]]
+  query = query
+    .. string.gsub(query, "arrow_function", "function_expression")
+    .. call_expression_query
   return lib.treesitter.parse_positions(path, query, { nested_tests = true })
 end
 


### PR DESCRIPTION
Hi @marilari88,

I work on a project that makes use of a wrapper to setup some of our tests in the shape of:

```typescript
it('can do something with A', TestFactory.build('A'));
```

This PR includes an small update to the base tree-sitter query to support that use case.